### PR TITLE
Fix reverse component relations

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,2 @@
+{:paths ["src"]
+ :deps {org.clojure/core.match {:mvn/version "0.3.0"}}}

--- a/src/posh/lib/datom_matcher.cljc
+++ b/src/posh/lib/datom_matcher.cljc
@@ -44,16 +44,16 @@
              (cons (first patterns) leftover-patterns)))))
 
 (defn reduce-patterns [patterns]
-  (loop [new-patterns []
-         leftover-patterns patterns]
-    (if (empty? leftover-patterns)
-      new-patterns
-      (if (let [id (ffirst leftover-patterns)]
-            (or (set? id) (number? id)))
-        (let [r (combine-entids #{} (rest (first leftover-patterns))
-                                leftover-patterns
-                                new-patterns
-                                [])]
-          (recur (:new-patterns r) (:leftover-patterns r)))
-        (recur (cons (first leftover-patterns) new-patterns) (rest leftover-patterns))))))
-
+  (distinct
+   (loop [new-patterns []
+          leftover-patterns patterns]
+     (if (empty? leftover-patterns)
+       new-patterns
+       (if (let [id (ffirst leftover-patterns)]
+             (or (set? id) (number? id)))
+         (let [r (combine-entids #{} (rest (first leftover-patterns))
+                                 leftover-patterns
+                                 new-patterns
+                                 [])]
+           (recur (:new-patterns r) (:leftover-patterns r)))
+         (recur (cons (first leftover-patterns) new-patterns) (rest leftover-patterns)))))))

--- a/src/posh/lib/datom_matcher.cljc
+++ b/src/posh/lib/datom_matcher.cljc
@@ -57,15 +57,3 @@
           (recur (:new-patterns r) (:leftover-patterns r)))
         (recur (cons (first leftover-patterns) new-patterns) (rest leftover-patterns))))))
 
-(comment
-  (datom-match? '[#{123 88 32} :jimmy _] '[123 :jimmy "hey"])
-
-  (datom-match-patterns? '[[88 :deandog]
-                           [#{123 88 32} :jimmy _]] '[123 :jimmy "hey"])
-
-  (any-datoms-match? '[[88 :deandog]
-                       [#{123 88 32} :jimmy _]]
-                     '[[28882 :major "billy"] [123 :jimmy "hey"]])
-
-  
-  )

--- a/src/posh/lib/pull_analyze.cljc
+++ b/src/posh/lib/pull_analyze.cljc
@@ -62,13 +62,10 @@
        (ref? schema k)
        (concat
         (cond
-         (and (not r?) (cardinality-one? schema k))
-         (concat
-          [[entity-id k (:db/id v)]]
-          (tx-datoms-for-pull-map schema (:db/id v) v))
 
-         (or r? (cardinality-one? schema k))
+         (cardinality-one? schema k)
          (concat
+          (when-not r? [[entity-id k (:db/id v)]])
           (mapcat #(tx-datoms-for-pull-map
                     schema
                     (:db/id %)
@@ -77,7 +74,7 @@
 
          (cardinality-many? schema k)
          (concat
-          (if-not r? (mapcat #(vector [entity-id k (:db/id %)]) v))
+          (when-not r? (mapcat #(vector [entity-id k (:db/id %)]) v))
           (mapcat #(tx-datoms-for-pull-map
                     schema
                     (:db/id %)

--- a/src/posh/lib/pull_analyze.cljc
+++ b/src/posh/lib/pull_analyze.cljc
@@ -138,19 +138,18 @@
                          (remove (set val-keys))
                          (map (fn [k] {k [:db/id]})))
         starred?    (some #{'*} val-keys)
-        pull-maps   (reduce merge (concat ref-keys (filter map? pull-pattern)))
-        db-id       (or (:db/id affected-pull) (if (and (vector? affected-pull) (= :db/id (first affected-pull))) (second affected-pull)))]
-    (when db-id
+        pull-maps   (reduce merge (concat ref-keys (filter map? pull-pattern)))]
+    (when (:db/id affected-pull)
       (concat
        (when (not (or refs-only? (empty? val-keys)))
-         [[db-id (if starred? '_ (set val-keys)) '_]])
+         [[(:db/id affected-pull) (if starred? '_ (set val-keys)) '_]])
        (mapcat (fn [[ref-key ref-pull]]
                  (let [r? (reverse-lookup? ref-key)
                        unrev-key (if r? (reverse-lookup ref-key) ref-key)]
                    (concat
                     (if r?
-                      [['_ unrev-key db-id]]
-                      [[db-id ref-key '_]])
+                      [['_ unrev-key (:db/id affected-pull)]]
+                      [[(:db/id affected-pull) ref-key '_]])
                     (cond
                      (recursive-val? ref-pull)
                      (when (ref-key affected-pull)

--- a/test/posh/lib/datascript_test.cljc
+++ b/test/posh/lib/datascript_test.cljc
@@ -6,7 +6,7 @@
 (deftest test-simple-query
   (let [conn (dt/create-conn {:a {:db/unique :db.unique/identity}})
         _ (d/posh! conn)
-        tran-a (d/transact! conn [{:a "foo"}])
+        _ (d/transact! conn [{:a "foo"}])
         eid (->> (d/q '[:find ?e
                         :where [?e :a "foo"]] conn)
                  deref
@@ -19,8 +19,8 @@
   (testing "Lookups refs work within query :in as entity-id"
     (let [conn (dt/create-conn {:a {:db/unique :db.unique/identity}})
           _ (d/posh! conn)
-          tran-a (d/transact! conn [{:a "foo"
-                                     :b "bar"}])
+          _ (d/transact! conn [{:a "foo"
+                                :b "bar"}])
           b (->> (d/q '[:find ?b
                         :in $ ?lookup
                         :where
@@ -35,8 +35,8 @@
     (let [conn (dt/create-conn {:a {:db/unique :db.unique/identity}
                                 :b {:db/valueType :db.type/ref}})
           _ (d/posh! conn)
-          tran-a (d/transact! conn [{:a "foo"
-                                     :b {:a "foo2"}}])
+          _ (d/transact! conn [{:a "foo"
+                                :b {:a "foo2"}}])
           b (->> (d/q '[:find ?aval
                         :in $ ?lookup
                         :where
@@ -51,15 +51,15 @@
   (testing "Lookups refs work via db/transact"
     (let [conn (dt/create-conn {:a {:db/unique :db.unique/identity}})
           _ (d/posh! conn)
-          tran-a (d/transact! conn [{:a "foo"
-                                     :b "bar"}])
+          _ (d/transact! conn [{:a "foo"
+                                :b "bar"}])
           ent-a (->> (d/q '[:find ?e
                             :where [?e :a "foo"]] conn)
                      deref
                      ffirst
                      (dt/entity (dt/db conn))
                      dt/touch)
-          tran-b (d/transact! conn [[:db/add [:a "foo"] :b "zim"]])
+          _ (d/transact! conn [[:db/add [:a "foo"] :b "zim"]])
           ent-b (->> (d/q '[:find ?e
                             :where [?e :a "foo"]] conn)
                      deref

--- a/test/posh/lib/datom_matcher_test.cljc
+++ b/test/posh/lib/datom_matcher_test.cljc
@@ -1,0 +1,13 @@
+(ns posh.lib.datom-matcher-test
+  (:require [clojure.test :refer [is are deftest testing]]
+            [posh.lib.datom-matcher :as dm]))
+
+(deftest datom-match-pattern?-test
+  (are [pattern datom]
+    (is (true? (dm/datom-match-pattern? pattern datom)))
+
+    [] [1 :some/kikka "kukka"]
+    ['_] [1 :some/kikka "kukka"]
+    [1] [1 :some/kikka "kukka"]
+    [#{1}] [1 :some/kikka "kukka"]
+    ['_ :some/kikka #{"kukka"}] [1 :some/kikka "kukka"]))


### PR DESCRIPTION
Before the fix, the component-type reverse lookups were not registered. Fixes that and ensuring that also `:datoms` are accumulated correctly in all cases over different relations: `:one`, `:one + :isComponent` + `:many` both ways. Also ensured that no duplicate `:datoms` or `:patterns` are collected.

Bonus: `deps.edn` so we can depend on the lib directly with deps..