### PR TITLE
Fix #13: New mechanism to access DataScript listeners

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,25 +12,25 @@
   :profiles {:dev {:plugins [[lein-githooks "0.1.0"]]
                    :githooks {:auto-install true
                               :pre-push ["lein kaocha"]}}
-             :test {:dependencies [[datascript "0.18.6"]
-                                   [reagent "0.9.0-rc2"]
+             :test {:dependencies [[datascript "1.6.3"]
+                                   [reagent "1.2.0"]
                                    [org.clojure/clojure "1.10.1"]
                                    [org.clojure/clojurescript "1.10.520"]]}
              :kaocha {:dependencies [[lambdaisland/kaocha "0.0-554"]
-                                     [datascript "0.18.6"]
+                                     [datascript "1.6.3"]
                                      [com.datomic/datomic-free "0.9.5407"]
-                                     [reagent "0.9.0-rc2"]
+                                     [reagent "1.2.0"]
                                      [org.clojure/clojure "1.10.1"]
                                      [org.clojure/clojurescript "1.10.520"]
-                                     [org.clojure/test.check "0.9.0"]
-                                     ]}}
+                                     [org.clojure/test.check "0.9.0"]]}}
+
   :cljsbuild {:builds [ {:id "posh"
                          :source-paths ["src/"]
                          :figwheel false
                          :compiler {:main "posh.core"
                                     :asset-path "js"
                                     :output-to "resources/public/js/main.js"
-                                    :output-dir "resources/public/js"} } ]}
+                                    :output-dir "resources/public/js"}}]}
   :scm {:name "git"
         :url "https://github.com/denistakeda/posh"}
   :aliases {"kaocha" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner"]})

--- a/src/posh/plugin_base.cljc
+++ b/src/posh/plugin_base.cljc
@@ -62,11 +62,17 @@
                                    (set-conn-listener! dcfg posh-atom (first conns) db-id)
                                    (:schema @(first conns))))))))))
 
+(defn- conn->listeners
+  [conn]
+  (if-some [meta-listeners (:listeners (meta conn))]
+     ;; DataScript < 1.6
+     @meta-listeners
+     ;; Datascript >= 1.6
+     (:listeners @(:atom conn))))
 
-;; Posh's state atoms are stored inside a listener in the meta data of
-;; the datascript conn
+;; Posh's state atoms are stored inside its DataScript listener.
 (defn get-conn-var [dcfg conn var]
-  ((:posh-dispenser @(:listeners (meta conn))) var))
+  ((:posh-dispenser (conn->listeners conn)) var))
 
 (defn get-posh-atom [dcfg poshdb-or-conn]
   (if ((:conn? dcfg) poshdb-or-conn)

--- a/test/posh/lib/datascript_test.cljc
+++ b/test/posh/lib/datascript_test.cljc
@@ -200,8 +200,8 @@
         ;; direct
         [:parent/score :name]
         [:parent/id "grandma"]
-        '{:datoms {:posh [[1 :parent/score 16]
-                          [1 :name "margit"]]},
+        '{:datoms {:posh [[1 :name "margit"]
+                          [1 :parent/score 16]]},
           :patterns {:posh [[#{1} #{:name :parent/score} _]
                             [_ :parent/id "grandma"]]}}
 
@@ -209,11 +209,11 @@
         [:name :parent/score {:parent/child [:name {:parent/child [:name]}]}]
         [:parent/id "grandma"]
         '{:datoms {:posh ([1 :name "margit"]
-                          [1 :parent/score 16]
                           [1 :parent/child 2]
                           [2 :name "make"]
                           [2 :parent/child 3]
-                          [3 :name "eeva"])},
+                          [3 :name "eeva"]
+                          [1 :parent/score 16])},
           :patterns {:posh ([#{1 2} :parent/child _]
                             [#{3 2} #{:name} _]
                             [#{1} #{:name :parent/score} _]


### PR DESCRIPTION
The breaking change is documented at
https://github.com/tonsky/datascript/releases/tag/1.6.0.

This change also updates the test dependencies to the latest versions of DataScript and Reagent. And there are a couple minor updates to fragile test cases, as datoms aren't being returned in exactly the same order.

The automated tests don't support a DataScript version matrix, but I've run the tests against 1.4.0 and 1.6.3 (pre- and post-change). Plus testing against my own application, of course.